### PR TITLE
curious to see if X-Content-Type-Options: nosniff will block a script…

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,2 +1,3 @@
 /*
   X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff


### PR DESCRIPTION
… tag without type explicitly set